### PR TITLE
Change how quantize counts colors.

### DIFF
--- a/quantize.js
+++ b/quantize.js
@@ -426,10 +426,15 @@ var MMCQ = (function() {
         // inner function to do the iteration
 
         function iter(lh, target) {
-            var ncolors = 1,
+            var ncolors = lh.size(),
                 niters = 0,
                 vbox;
             while (niters < maxIterations) {
+                if (ncolors >= target) return;
+                if (niters++ > maxIterations) {
+                    // console.log("infinite loop; perhaps too few pixels!");
+                    return;
+                }
                 vbox = lh.pop();
                 if (!vbox.count()) { /* just put it back */
                     lh.push(vbox);
@@ -450,11 +455,6 @@ var MMCQ = (function() {
                     lh.push(vbox2);
                     ncolors++;
                 }
-                if (ncolors >= target) return;
-                if (niters++ > maxIterations) {
-                    // console.log("infinite loop; perhaps too few pixels!");
-                    return;
-                }
             }
         }
 
@@ -471,7 +471,7 @@ var MMCQ = (function() {
         }
 
         // next set - generate the median cuts using the (npix * vol) sorting.
-        iter(pq2, maxcolors - pq2.size());
+        iter(pq2, maxcolors);
 
         // calculate the actual colors
         var cmap = new CMap();


### PR DESCRIPTION
The inner function used by quantize was counting the number of colors added to the palette, starting from 1. This only works when the PQueue passed contains only 1 VBox; but the iter function is called twice, and the second time, the VBox contains more than one color. This means that in some circumstances it was counting the number of colors added incorrectly, and so quantize.js would sometimes return the wrong number of colors . This commit changes iter to start counting at the actual number of colors in the PQueue, so that it always returns the number of colors requested.