### PR TITLE
Fix map fn of ColorMap

### DIFF
--- a/quantize.js
+++ b/quantize.js
@@ -187,9 +187,9 @@ var MMCQ = (function() {
         },
         contains: function(pixel) {
             var vbox = this,
-                rval = pixel[0] >> rshift;
-            gval = pixel[1] >> rshift;
-            bval = pixel[2] >> rshift;
+                rval = pixel[0] >> rshift,
+                gval = pixel[1] >> rshift,
+                bval = pixel[2] >> rshift;
             return (rval >= vbox.r1 && rval <= vbox.r2 &&
                 gval >= vbox.g1 && gval <= vbox.g2 &&
                 bval >= vbox.b1 && bval <= vbox.b2);


### PR DESCRIPTION
This fixes the Vbox.contains method, so we can use the map fn of ColorMap